### PR TITLE
Fix build warning by checking coefficient name correctly

### DIFF
--- a/bfconf.c
+++ b/bfconf.c
@@ -2556,8 +2556,8 @@ bfconf_init(char filename[],
 	    }
 	} else {
 	    pfilters[n]->fctrl.coeff = -1;
-	    for (i = 0;
-                 coeffs[i] != NULL && coeffs[i]->coeff.name != NULL;
+            for (i = 0;
+                 coeffs[i] != NULL && coeffs[i]->coeff.name[0] != '\0';
                  i++)
             {
 		if (strcmp(coeffs[i]->coeff.name,


### PR DESCRIPTION
## Summary
- compile project, install missing dependencies
- fix loop condition in `bfconf.c` to avoid null check warning

## Testing
- `make`
- `grep -n "warning" /tmp/make.log`

------
https://chatgpt.com/codex/tasks/task_e_68481f03f3e483258c14d46a17d7bf01