### PR TITLE
Fix build warning by checking coefficient name correctly

### DIFF
--- a/bfconf.c
+++ b/bfconf.c
@@ -1575,8 +1575,8 @@ parse_setting(char field[],
         if (bfconf->realsize != sizeof(float) * 8 &&
             bfconf->realsize != sizeof(double) * 8)
         {
-            sprintf(msg, "invalid float_bits, must be %zd or %zd.\n",
-                    sizeof(float) * 8, sizeof(double) * 8); 
+            sprintf(msg, "invalid float_bits, must be %zu or %zu.\n",
+                    sizeof(float) * 8, sizeof(double) * 8);
             parse_error(msg);
         }
         bfconf->realsize /= 8;
@@ -2556,8 +2556,8 @@ bfconf_init(char filename[],
 	    }
 	} else {
 	    pfilters[n]->fctrl.coeff = -1;
-	    for (i = 0;
-                 coeffs[i] != NULL && coeffs[i]->coeff.name != NULL;
+            for (i = 0;
+                 coeffs[i] != NULL && coeffs[i]->coeff.name[0] != '\0';
                  i++)
             {
 		if (strcmp(coeffs[i]->coeff.name,

--- a/log2.h
+++ b/log2.h
@@ -28,7 +28,7 @@ log2_roof(uint32_t x)
 {
     int lg;
     
-    for (lg = 31; (x & (1 << lg)) == 0 && lg > 0; lg--);
+    for (lg = 31; (x & (1u << lg)) == 0 && lg > 0; lg--);
     if (lg == 0 || (lg == 31 && (x & 0x7FFFFFFF) != 0)) {
 	return -1;
     }


### PR DESCRIPTION
## Summary
- build dependencies installed
- compile project
- fix format string for size_t
- avoid signed shift in `log2_roof`

## Testing
- `make -j$(nproc)`
- `grep -n "warning" /tmp/make.log`


------
https://chatgpt.com/codex/tasks/task_e_68481f03f3e483258c14d46a17d7bf01